### PR TITLE
Improved Zombie Target Finding (+ some minor visual / audio tweaks)

### DIFF
--- a/src/main/java/parallelmc/pz/GameManager.java
+++ b/src/main/java/parallelmc/pz/GameManager.java
@@ -177,7 +177,7 @@ public class GameManager {
      * across the map</i>
      */
     public Player getRandomSurvivorByDistance(Zombie zombie){
-        List<ZombiesPlayer> targets = players.values().stream().filter(x -> x.getTeam() == Team.SURVIVOR).toList();
+        List<ZombiesPlayer> targets = players.values().stream().filter(x -> x.getTeam() == Team.ZOMBIE).toList();
         ArrayList<Pair<Player, Integer>> arr = new ArrayList<>();
 
         for (ZombiesPlayer player: targets) {
@@ -187,14 +187,18 @@ public class GameManager {
                 // convert shorter distances to be higher weights
                 int weight = (int) ((1./distance) * 100);
 
-                arr.add(new Pair<>(player.getMcPlayer(), weight));
+                arr.add(new Pair<>(player.getMcPlayer(), Math.min(weight, 500)));
             }
         }
 
         if (arr.size() == 0){
-            ParallelZombies.log(Level.WARNING, "Failed to find a target for zombie spawn.");
+            ParallelZombies.log(Level.WARNING, String.format("Failed to find a target for zombie %s spawn.", zombie.getUniqueId()));
             return null;
         }
+
+        ParallelZombies.log(Level.FINER,
+                String.format("Zombie %s Targets: %s", String.valueOf(zombie.getUniqueId()), arr)
+                );
 
         return weightedChoice(arr);
 

--- a/src/main/java/parallelmc/pz/GameManager.java
+++ b/src/main/java/parallelmc/pz/GameManager.java
@@ -177,7 +177,7 @@ public class GameManager {
      * across the map</i>
      */
     public Player getRandomSurvivorByDistance(Zombie zombie){
-        List<ZombiesPlayer> targets = players.values().stream().filter(x -> x.getTeam() == Team.ZOMBIE).toList();
+        List<ZombiesPlayer> targets = players.values().stream().filter(x -> x.getTeam() == Team.SURVIVOR).toList();
         ArrayList<Pair<Player, Integer>> arr = new ArrayList<>();
 
         for (ZombiesPlayer player: targets) {

--- a/src/main/java/parallelmc/pz/ParallelZombies.java
+++ b/src/main/java/parallelmc/pz/ParallelZombies.java
@@ -1,6 +1,5 @@
 package parallelmc.pz;
 
-import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
 import org.bukkit.Location;
@@ -10,11 +9,13 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-import parallelmc.pz.commands.*;
+import parallelmc.pz.commands.StartGame;
 import parallelmc.pz.events.*;
 
 import java.io.File;
 import java.util.logging.Level;
+
+import static parallelmc.pz.utils.ZombieUtils.createMessage;
 
 public class ParallelZombies extends JavaPlugin {
     public static Level LOG_LEVEL = Level.INFO;
@@ -78,8 +79,11 @@ public class ParallelZombies extends JavaPlugin {
     public static void log(Level level, String message) { Bukkit.getLogger().log(level, "[ParallelZombies] " + message); }
 
     public static void sendMessageTo(Player player, String message) {
-        Component msg = Component.text("§3[§f§lZombies§3] §a" + message);
-        player.sendMessage(msg);
+        player.sendMessage(createMessage(message));
+    }
+
+    public static void sendActionBarTo(Player player, String message){
+        player.sendActionBar(createMessage(message));
     }
 
     public static void sendMessage(String message) {

--- a/src/main/java/parallelmc/pz/ParallelZombies.java
+++ b/src/main/java/parallelmc/pz/ParallelZombies.java
@@ -18,7 +18,7 @@ import java.util.logging.Level;
 import static parallelmc.pz.utils.ZombieUtils.createMessage;
 
 public class ParallelZombies extends JavaPlugin {
-    public static Level LOG_LEVEL = Level.INFO;
+    public static Level LOG_LEVEL = Level.FINER;//Level.INFO;
     public static GameManager gameManager;
 
     @Override

--- a/src/main/java/parallelmc/pz/ParallelZombies.java
+++ b/src/main/java/parallelmc/pz/ParallelZombies.java
@@ -2,17 +2,13 @@ package parallelmc.pz;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameRule;
-import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 import parallelmc.pz.commands.StartGame;
 import parallelmc.pz.events.*;
 
-import java.io.File;
 import java.util.logging.Level;
 
 import static parallelmc.pz.utils.ZombieUtils.createMessage;
@@ -21,11 +17,14 @@ public class ParallelZombies extends JavaPlugin {
     public static Level LOG_LEVEL = Level.FINER;//Level.INFO;
     public static GameManager gameManager;
 
+    public static ParallelZombies instance;
+
     @Override
     public void onLoad() { }
 
     @Override
     public void onEnable() {
+        instance = this;
         PluginManager manager = Bukkit.getPluginManager();
 
         manager.registerEvents(new OnBlockBreak(), this);
@@ -40,27 +39,21 @@ public class ParallelZombies extends JavaPlugin {
 
         this.getCommand("startgame").setExecutor(new StartGame());
 
-        // TODO: support loading multiple maps
+        // todo: this should be dynamic
         World world = this.getServer().getWorld("world");
         if (world == null) {
             log(Level.SEVERE, "Could not find map world!");
             return;
         }
 
-        FileConfiguration config = new YamlConfiguration();
-        try {
-            config.load(new File(this.getDataFolder(), "map.yml"));
-        } catch (Exception e) {
-            ParallelZombies.log(Level.WARNING, "Failed to load map");
-            ParallelZombies.log(Level.WARNING, e.toString());
+        ZombiesMap map = ZombiesMap.loadFromConfig("map.yml");
+
+        if (map == null){
+            log("An error occurred loading map.");
             return;
         }
-        ZombiesMap map = new ZombiesMap(
-                "map",
-                world,
-                new Location(world, config.getDouble("players.x"), config.getDouble("players.y"), config.getDouble("players.z")),
-                new Location(world, config.getDouble("zombies.x"), config.getDouble("zombies.y"), config.getDouble("zombies.z")));
         ParallelZombies.log(Level.WARNING, "Loaded map config");
+
         gameManager = new GameManager(this, map);
 
         world.setGameRule(GameRule.ANNOUNCE_ADVANCEMENTS, false);

--- a/src/main/java/parallelmc/pz/ZombiesMap.java
+++ b/src/main/java/parallelmc/pz/ZombiesMap.java
@@ -1,30 +1,114 @@
 package parallelmc.pz;
 
+import com.mojang.datafixers.util.Pair;
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import parallelmc.pz.utils.ZombieUtils;
 
-import java.util.Random;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.logging.Level;
+
+import static parallelmc.pz.ParallelZombies.log;
+import static parallelmc.pz.utils.ZombieUtils.getRandomLocationInRadius;
 
 public class ZombiesMap {
     public String name;
-    // TODO: make these areas instead of a single point
-    public final Location playerSpawn;
-    public final Location zombieSpawn;
+    public final ArrayList<Pair<Location, Double>> playerSpawns;
+    public final ArrayList<Pair<Location, Double>> zombieSpawns;
     public final World world;
 
-    public ZombiesMap(String name, World world, Location playerSpawn, Location zombieSpawn) {
+
+
+    public ZombiesMap(String name, World world, ArrayList<Pair<Location, Double>> playerSpawns, ArrayList<Pair<Location, Double>> zombieSpawns) {
         this.name = name;
         this.world = world;
-        this.playerSpawn = playerSpawn;
-        this.zombieSpawn = zombieSpawn;
+        this.playerSpawns = playerSpawns;
+        this.zombieSpawns = zombieSpawns;
     }
 
+    /**
+     * Get a random player spawn point
+     */
     public Location getPlayerSpawnPoint() {
-        return this.playerSpawn;
+        // First, select a random spawn 'zone' from the list
+        Pair<Location, Double> spawn = playerSpawns.get(ZombieUtils.rng.nextInt(playerSpawns.size()-1));
+
+        // if the radius is 0, just use the exact spot
+        if(spawn.getSecond() == 0d) return spawn.getFirst();
+
+        // otherwise, get a random spot in that radius
+        return getRandomLocationInRadius(spawn.getFirst(), spawn.getSecond());
     }
 
+    /**
+     * Get a random zombie spawn point
+     */
     public Location getZombieSpawnPoint() {
-        return this.zombieSpawn;
+        // First, select a random spawn 'zone' from the list
+        Pair<Location, Double> spawn = zombieSpawns.get(ZombieUtils.rng.nextInt(zombieSpawns.size()-1));
+
+        // if the radius is 0, just use the exact spot
+        if(spawn.getSecond() == 0d) return spawn.getFirst();
+
+        // otherwise, get a random spot in that radius
+        return getRandomLocationInRadius(spawn.getFirst(), spawn.getSecond());
     }
 
+    /**
+     * Loads map from the specified config file name
+     * @param fileName The yml {@link String filename} (found in ~/plugins/ParallelZombies/)
+     * @return New instance of {@link ZombiesMap}
+     */
+    public static ZombiesMap loadFromConfig(String fileName){
+        // todo: this should be dynamic
+        World world = ParallelZombies.instance.getServer().getWorld("world");
+        if (world == null) {
+            log(Level.SEVERE, "Could not find map world!");
+            return null;
+        }
+
+        FileConfiguration config = new YamlConfiguration();
+        try {
+            config.load(new File(ParallelZombies.instance.getDataFolder(), fileName));
+        } catch (Exception e) {
+            ParallelZombies.log(Level.WARNING, "Failed to load map");
+            ParallelZombies.log(Level.WARNING, e.toString());
+            return null;
+        }
+
+        ArrayList<HashMap<String, Double>> _playerSpawns = (ArrayList<HashMap<String, Double>>) config.getList("players");
+        ArrayList<HashMap<String, Double>> _zombieSpawns = (ArrayList<HashMap<String, Double>>) config.getList("zombies");
+
+        ArrayList<Pair<Location, Double>> playerSpawns = new ArrayList<>();
+        ArrayList<Pair<Location, Double>> zombieSpawns = new ArrayList<>();
+
+        if(_playerSpawns == null || _zombieSpawns == null){
+            log(Level.SEVERE, "Error loading map. Make sure you have player and zombie spawns specified.");
+            return null;
+        }
+
+        try {
+            for (HashMap<String, Double> spawn : _playerSpawns) {
+                playerSpawns.add(new Pair<>(
+                        new Location(world, spawn.get("x"), spawn.get("y"), spawn.get("z")),
+                        spawn.getOrDefault("radius", 0d)));
+            }
+
+            for (HashMap<String, Double> spawn : _zombieSpawns) {
+                zombieSpawns.add(new Pair<>(
+                        new Location(world, spawn.get("x"), spawn.get("y"), spawn.get("z")),
+                        spawn.getOrDefault("radius", 0d)));
+            }
+        }
+        catch (Exception e){
+            log(Level.SEVERE, "Error loading map. " + e.getLocalizedMessage());
+            return null;
+        }
+
+        return new ZombiesMap("map", world, playerSpawns, zombieSpawns);
+    }
 }

--- a/src/main/java/parallelmc/pz/ZombiesPlayer.java
+++ b/src/main/java/parallelmc/pz/ZombiesPlayer.java
@@ -143,10 +143,10 @@ public class ZombiesPlayer {
         bossBar.progress(1f);
         player.showBossBar(bossBar);
         new BukkitRunnable() {
-            int cooldown = 8;
+            int cooldown = 80;
             @Override
             public void run() {
-                bossBar.progress(cooldown / 8f);
+                bossBar.progress(cooldown / 80f);
                 if (cooldown <= 0) {
                     leapCooldown = false;
                     player.hideBossBar(bossBar);
@@ -154,7 +154,7 @@ public class ZombiesPlayer {
                 }
                 cooldown--;
             }
-        }.runTaskTimer(ParallelZombies.gameManager.getPlugin(), 0L, 20L);
+        }.runTaskTimer(ParallelZombies.gameManager.getPlugin(), 0L, 2L);
     }
 
     private ItemStack unbreakableItem(Material material) {

--- a/src/main/java/parallelmc/pz/ZombiesPlayer.java
+++ b/src/main/java/parallelmc/pz/ZombiesPlayer.java
@@ -67,7 +67,7 @@ public class ZombiesPlayer {
     public void updateEndingBoard(int countdown) {
         this.board.updateLines(
                 "",
-                "§Returning to lobby in:",
+                "Returning to lobby in:",
                 countdown + " seconds"
         );
     }

--- a/src/main/java/parallelmc/pz/commands/StartGame.java
+++ b/src/main/java/parallelmc/pz/commands/StartGame.java
@@ -8,13 +8,22 @@ import org.jetbrains.annotations.NotNull;
 import parallelmc.pz.GameState;
 import parallelmc.pz.ParallelZombies;
 
+import static parallelmc.pz.utils.ZombieUtils.createMessage;
+
 public class StartGame implements CommandExecutor {
     @Override
     public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String label, String[] args) {
         if (commandSender.isOp() || commandSender instanceof ConsoleCommandSender) {
             if (ParallelZombies.gameManager.gameState == GameState.PREGAME) {
                 ParallelZombies.gameManager.startGame();
+                commandSender.sendMessage(createMessage("Starting Game..."));
             }
+            else{
+                commandSender.sendMessage(createMessage("Cannot start a game right now."));
+            }
+        }
+        else {
+            commandSender.sendMessage(createMessage("You do not have access to this command."));
         }
         return true;
     }

--- a/src/main/java/parallelmc/pz/events/OnPlayerJoin.java
+++ b/src/main/java/parallelmc/pz/events/OnPlayerJoin.java
@@ -25,7 +25,9 @@ public class OnPlayerJoin implements Listener {
         p.addPotionEffect(new PotionEffect(PotionEffectType.SATURATION, PotionEffect.INFINITE_DURATION, 0));
         AttributeInstance instance = p.getAttribute(Attribute.GENERIC_ATTACK_SPEED);
         if (instance != null) {
-            instance.setBaseValue(15.9);
+            // having this number this high hides the attack indicator from flickering up
+            // it doesn't increase the attack speed at all from the previous 15.9 value.
+            instance.setBaseValue(30);
         }
         ParallelZombies.gameManager.addPlayer(event.getPlayer());
     }

--- a/src/main/java/parallelmc/pz/events/OnRightClick.java
+++ b/src/main/java/parallelmc/pz/events/OnRightClick.java
@@ -1,5 +1,7 @@
 package parallelmc.pz.events;
 
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.sound.Sound;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -18,12 +20,20 @@ public class OnRightClick implements Listener {
                 event.setCancelled(true);
                 ZombiesPlayer pl = ParallelZombies.gameManager.getPlayer(player);
                 if (pl.isLeapCooldown()) {
-                    ParallelZombies.sendMessageTo(player, "Your Leap is on cooldown!");
+                    ParallelZombies.sendActionBarTo(player, "Your Leap is on cooldown!");
+                    player.playSound(
+                            Sound.sound(Key.key("ui.toast.in"),
+                                    Sound.Source.MASTER, 0.5f, 0.9f)
+                    );
                     return;
                 }
                 if (player.getInventory().getItemInMainHand().getType() == Material.STONE_AXE) {
                     player.setVelocity(player.getLocation().getDirection().normalize().multiply(1.5f));
-                    ParallelZombies.sendMessageTo(player, "You used Leap!");
+                    ParallelZombies.sendActionBarTo(player, "You used Leap!");
+                    player.playSound(
+                            Sound.sound(Key.key("item.trident.riptide_1"),
+                                    Sound.Source.MASTER, 0.5f, 0.9f)
+                    );
                     pl.startLeapCooldown();
                 }
             }

--- a/src/main/java/parallelmc/pz/utils/ZombieUtils.java
+++ b/src/main/java/parallelmc/pz/utils/ZombieUtils.java
@@ -1,0 +1,27 @@
+package parallelmc.pz.utils;
+
+import com.mojang.datafixers.util.Pair;
+
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.TreeMap;
+
+public class ZombieUtils {
+    /**
+     * Weighted Randomizer
+     * @param values An {@link ArrayList} of {@link Pair Pairs} of {@link T} & it's {@link Integer weight}
+     * @return Weighted choice of {@link T}
+     * @param <T> The type of object we are randomizing
+     */
+    public static <T> T weightedChoice(ArrayList<Pair<T, Integer>> values){
+        TreeMap<Integer, T> map = new TreeMap<>();
+        Random rng = new Random();
+        int t = 0;
+
+        for (Pair<T, Integer> _pair: values) {
+            t +=_pair.getSecond();
+            map.put(t, _pair.getFirst());
+        }
+        return map.ceilingEntry(rng.nextInt(t) + 1).getValue();
+    }
+}

--- a/src/main/java/parallelmc/pz/utils/ZombieUtils.java
+++ b/src/main/java/parallelmc/pz/utils/ZombieUtils.java
@@ -14,7 +14,6 @@ import java.util.TreeMap;
 public class ZombieUtils {
 
     public static final Random rng = new Random();
-    // TEXT
     public static TextComponent messagePrefix = Component.text('[')
             .color(NamedTextColor.AQUA)
             .append(Component.text("Zombies")
@@ -24,6 +23,9 @@ public class ZombieUtils {
             .append(Component.text(']'))
             .append(Component.text(' '));
 
+	/**
+	 * Creates a text component, making the message green and prefixing it with the [Zombies] prefix
+	 */
     public static TextComponent createMessage(String message){
         return messagePrefix
                 .append(Component.text(message).color(NamedTextColor.GREEN));

--- a/src/main/java/parallelmc/pz/utils/ZombieUtils.java
+++ b/src/main/java/parallelmc/pz/utils/ZombieUtils.java
@@ -5,12 +5,30 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.Location;
 
 import java.util.ArrayList;
 import java.util.Random;
 import java.util.TreeMap;
 
 public class ZombieUtils {
+
+    public static final Random rng = new Random();
+    // TEXT
+    public static TextComponent messagePrefix = Component.text('[')
+            .color(NamedTextColor.AQUA)
+            .append(Component.text("Zombies")
+                    .color(NamedTextColor.WHITE)
+                    .decoration(TextDecoration.BOLD, true)
+            )
+            .append(Component.text(']'))
+            .append(Component.text(' '));
+
+    public static TextComponent createMessage(String message){
+        return messagePrefix
+                .append(Component.text(message).color(NamedTextColor.GREEN));
+    }
+
     /**
      * Weighted Randomizer
      * @param values An {@link ArrayList} of {@link Pair Pairs} of {@link T} & it's {@link Integer weight}
@@ -29,17 +47,18 @@ public class ZombieUtils {
         return map.ceilingEntry(rng.nextInt(t) + 1).getValue();
     }
 
-    public static TextComponent messagePrefix = Component.text('[')
-            .color(NamedTextColor.AQUA)
-            .append(Component.text("Zombies")
-                    .color(NamedTextColor.WHITE)
-                    .decoration(TextDecoration.BOLD, true)
-            )
-            .append(Component.text(']'))
-            .append(Component.text(' '));
+    /**
+     * Get a random location in a {@link Double radius} from the {@link Location center}
+     * @param center The center {@link Location} of the spawn circle
+     * @param radius The maximum {@link Double radius} to choose from
+     * @return {@link Location}
+     */
+    public static Location getRandomLocationInRadius(Location center, double radius){
 
-    public static TextComponent createMessage(String message){
-        return messagePrefix
-                .append(Component.text(message).color(NamedTextColor.GREEN));
+        double x = rng.nextDouble(-radius, radius);
+        double z = rng.nextDouble(-radius, radius);
+
+        return center.add(x, 0, z);
     }
+
 }

--- a/src/main/java/parallelmc/pz/utils/ZombieUtils.java
+++ b/src/main/java/parallelmc/pz/utils/ZombieUtils.java
@@ -1,6 +1,10 @@
 package parallelmc.pz.utils;
 
 import com.mojang.datafixers.util.Pair;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 
 import java.util.ArrayList;
 import java.util.Random;
@@ -23,5 +27,19 @@ public class ZombieUtils {
             map.put(t, _pair.getFirst());
         }
         return map.ceilingEntry(rng.nextInt(t) + 1).getValue();
+    }
+
+    public static TextComponent messagePrefix = Component.text('[')
+            .color(NamedTextColor.AQUA)
+            .append(Component.text("Zombies")
+                    .color(NamedTextColor.WHITE)
+                    .decoration(TextDecoration.BOLD, true)
+            )
+            .append(Component.text(']'))
+            .append(Component.text(' '));
+
+    public static TextComponent createMessage(String message){
+        return messagePrefix
+                .append(Component.text(message).color(NamedTextColor.GREEN));
     }
 }


### PR DESCRIPTION
- Zombies now use a weighted randomization system to select a target -- this makes the zombie much more likely to choose close players, but still includes some randomization to make it interesting
- Added a sound effect to the Leap move
- Added a minor sound effect to the "[action] is on cooldown" popup
- Moved the leap actions to the 'action bar' instead of the chat
- Fixed the attack indicator flickering everytime you click
- The Leap Cooldown is now much smoother to please @Chipmunk48
- Added some convenience functions to utils to help with generating message text components 
- Added some feedback to the `parallelzombies:startgame` command
- Improved maps, can now have multiple spawns, spawns can now have radius, and made loading much more modular
```yml
name: map

players:
  - x: -64
    y: 65
    z: 17
    radius: 3
  - x: 20
    y: 64
    z: 60
    radius: 4
zombies:
  - x: -70
    y: 64
    z: 13
    radius: 3
  - x: -40
    y: 64
    z: 10
    radius: 8
```